### PR TITLE
Fixed access token code formatting in docs

### DIFF
--- a/docs/quickstarts/3_aspnetcore_and_apis.rst
+++ b/docs/quickstarts/3_aspnetcore_and_apis.rst
@@ -71,8 +71,8 @@ Using the access token
 ^^^^^^^^^^^^^^^^^^^^^^
 You can access the tokens in the session using the standard ASP.NET Core extension methods that you can find in the ``Microsoft.AspNetCore.Authentication`` namespace::
 
-var accessToken = await HttpContext.GetTokenAsync("access_token")
-var refreshToken = await HttpContext.GetTokenAsync("refresh_token");
+    var accessToken = await HttpContext.GetTokenAsync("access_token");
+    var refreshToken = await HttpContext.GetTokenAsync("refresh_token");
 
 For accessing the API using the access token, all you need to do is retrieve the token, and set it on your HttpClient::
 


### PR DESCRIPTION
**What issue does this PR address?**
Fixed some code formatting in the documentation, for retrieving access_token and refresh_token.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X ] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
N/A